### PR TITLE
Make it possible to store references from one identifier to another

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/stretchr/testify v1.3.0
 	go.etcd.io/bbolt v1.3.2
 )
+
+replace github.com/lyraproj/servicesdk => github.com/thallgren/servicesdk v0.0.0-20190614075654-f02c272830a4

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,6 @@ github.com/lyraproj/pcore v0.0.0-20190606102217-7824aee25201 h1:KlTHcsEPuRXi/cXY
 github.com/lyraproj/pcore v0.0.0-20190606102217-7824aee25201/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
-github.com/lyraproj/servicesdk v0.0.0-20190607070716-322c167d24a9 h1:u+JH8zmUaeXBjHnoc4YZz4MFOQwdClUuy7MXfX831f4=
-github.com/lyraproj/servicesdk v0.0.0-20190607070716-322c167d24a9/go.mod h1:+IR74NuJQyJnnRUUrtp44Lu5Iu950oAwW0oSs2isvXI=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
@@ -37,6 +35,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/thallgren/servicesdk v0.0.0-20190614075654-f02c272830a4 h1:PUnK7tgP7c+rnY4Ct4vojNZtwLOaBYQV8TWvHNw2zco=
+github.com/thallgren/servicesdk v0.0.0-20190614075654-f02c272830a4/go.mod h1:+IR74NuJQyJnnRUUrtp44Lu5Iu950oAwW0oSs2isvXI=
 go.etcd.io/bbolt v1.3.2 h1:Z/90sZLPOeCy2PwprqkFa25PdkusRzaj9P8zm/KNyvk=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -25,13 +25,13 @@ func deleteFile(filename string) {
 
 func checkGetInternal(t *testing.T, id serviceapi.Identity, externalID, internalID string) {
 	actual, err := id.GetInternal(externalID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, internalID, actual)
 }
 
 func checkGetExternal(t *testing.T, id serviceapi.Identity, internalID, externalID string) {
 	actual, err := id.GetExternal(internalID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, externalID, actual)
 }
 
@@ -41,7 +41,7 @@ func TestBasicFunctionality(t *testing.T) {
 	deleteFile(filename)
 	defer deleteFile(filename)
 	id, err := NewIdentity(filename)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Check there is no mapping
 	checkGetExternal(t, id, "i1", "")
@@ -51,7 +51,7 @@ func TestBasicFunctionality(t *testing.T) {
 
 	// Insert something
 	err = id.Associate("i1", "e1")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Check there is now a mapping
 	checkGetExternal(t, id, "i1", "e1")
@@ -66,15 +66,15 @@ func TestBasicFunctionalityAcrossInstances(t *testing.T) {
 	deleteFile(filename)
 	defer deleteFile(filename)
 	id, err := NewIdentity(filename)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Insert something
 	err = id.Associate("i1", "e1")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	//new up another identity service
 	id, err = NewIdentity(filename)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Check there is now a mapping
 	checkGetExternal(t, id, "i1", "e1")
@@ -87,7 +87,7 @@ func TestMultipleKeys(t *testing.T) {
 	deleteFile(filename)
 	defer deleteFile(filename)
 	id, err := NewIdentity(filename)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Check there is no mapping
 	checkGetExternal(t, id, "i1", "")
@@ -100,10 +100,10 @@ func TestMultipleKeys(t *testing.T) {
 	checkGetInternal(t, id, "e4", "")
 
 	// Insert something
-	require.Nil(t, id.Associate("i1", "e1"))
-	require.Nil(t, id.Associate("i2", "e2"))
-	require.Nil(t, id.Associate("i3", "e3"))
-	require.Nil(t, id.Associate("i4", "e4"))
+	require.NoError(t, id.Associate("i1", "e1"))
+	require.NoError(t, id.Associate("i2", "e2"))
+	require.NoError(t, id.Associate("i3", "e3"))
+	require.NoError(t, id.Associate("i4", "e4"))
 
 	// Check there is now a mapping
 	checkGetExternal(t, id, "i1", "e1")
@@ -138,13 +138,13 @@ func TestRemove(t *testing.T) {
 	deleteFile(filename)
 	defer deleteFile(filename)
 	id, err := NewIdentity(filename)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Insert something
-	require.Nil(t, id.Associate("i1", "e1"))
-	require.Nil(t, id.Associate("i2", "e2"))
-	require.Nil(t, id.Associate("i3", "e3"))
-	require.Nil(t, id.Associate("i4", "e4"))
+	require.NoError(t, id.Associate("i1", "e1"))
+	require.NoError(t, id.Associate("i2", "e2"))
+	require.NoError(t, id.Associate("i3", "e3"))
+	require.NoError(t, id.Associate("i4", "e4"))
 
 	// Check there is now a mapping
 	checkGetExternal(t, id, "i1", "e1")
@@ -192,16 +192,16 @@ func TestSearch(t *testing.T) {
 	deleteFile(filename)
 	defer deleteFile(filename)
 	id, err := NewIdentity(filename)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Insert something
-	require.Nil(t, id.Associate("a:i1", "e1"))
-	require.Nil(t, id.Associate("a:i2", "e2"))
-	require.Nil(t, id.Associate("b:i3", "e3"))
-	require.Nil(t, id.Associate("b:i4", "e4"))
+	require.NoError(t, id.Associate("a:i1", "e1"))
+	require.NoError(t, id.Associate("a:i2", "e2"))
+	require.NoError(t, id.Associate("b:i3", "e3"))
+	require.NoError(t, id.Associate("b:i4", "e4"))
 
 	mappings, err := id.Search("a:")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.EqualValues(t, 2, mappings.Len())
 }
 
@@ -210,10 +210,10 @@ func TestBumpEra(t *testing.T) {
 	deleteFile(filename)
 	defer deleteFile(filename)
 	id, err := NewIdentity(filename)
-	require.Nil(t, err)
-	require.Nil(t, id.BumpEra())
+	require.NoError(t, err)
+	require.NoError(t, id.BumpEra())
 	era, err := id.ReadEra()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.EqualValues(t, int64(1), era)
 }
 
@@ -222,21 +222,21 @@ func TestAccessSetEra(t *testing.T) {
 	deleteFile(filename)
 	defer deleteFile(filename)
 	id, err := NewIdentity(filename)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Insert something
-	require.Nil(t, id.Associate("a:i1", "e1"))
-	require.Nil(t, id.Associate("a:i2", "e2"))
+	require.NoError(t, id.Associate("a:i1", "e1"))
+	require.NoError(t, id.Associate("a:i2", "e2"))
 
 	// Check that era is zero
 	mappings, err := id.Search("a:")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.EqualValues(t, 2, mappings.Len())
 	require.EqualValues(t, int64(0), mappings.At(0).(px.List).At(3).(px.Number).Int())
 	require.EqualValues(t, int64(0), mappings.At(1).(px.List).At(3).(px.Number).Int())
 
 	// Bump era
-	require.Nil(t, id.BumpEra())
+	require.NoError(t, id.BumpEra())
 
 	// Access using getExternal
 	checkGetExternal(t, id, "a:i1", "e1")
@@ -244,7 +244,7 @@ func TestAccessSetEra(t *testing.T) {
 	// Check that era is one on the accessed element and zero
 	// on the one that wasn't accessed
 	mappings, err = id.Search("a:")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.EqualValues(t, 2, mappings.Len())
 	require.EqualValues(t, int64(1), mappings.At(0).(px.List).At(3).(px.Number).Int())
 	require.EqualValues(t, int64(0), mappings.At(1).(px.List).At(3).(px.Number).Int())
@@ -255,27 +255,27 @@ func TestSweep(t *testing.T) {
 	deleteFile(filename)
 	defer deleteFile(filename)
 	id, err := NewIdentity(filename)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Insert something
-	require.Nil(t, id.Associate("a:i1", "e1"))
-	require.Nil(t, id.Associate("a:i2", "e2"))
-	require.Nil(t, id.Associate("a:i3", "e3"))
+	require.NoError(t, id.Associate("a:i1", "e1"))
+	require.NoError(t, id.Associate("a:i2", "e2"))
+	require.NoError(t, id.Associate("a:i3", "e3"))
 
 	// Bump era
-	require.Nil(t, id.BumpEra())
+	require.NoError(t, id.BumpEra())
 
 	// Access using getExternal
 	checkGetExternal(t, id, "a:i1", "e1")
 	checkGetExternal(t, id, "a:i2", "e2")
-	require.Nil(t, id.RemoveInternal("a:i2"))
+	require.NoError(t, id.RemoveInternal("a:i2"))
 
 	// Check that element that wasn't accessed is found by SearchGarbage
-	require.Nil(t, id.Sweep("a:"))
+	require.NoError(t, id.Sweep("a:"))
 
 	// Retrieve the garbage bin
 	garbage, err := id.Garbage("")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.EqualValues(t, 2, garbage.Len())
 
 	// Accessed between BumpEra and Sweep and then explicitly removed
@@ -287,39 +287,75 @@ func TestSweep(t *testing.T) {
 	require.EqualValues(t, int64(0), garbage.At(1).(px.List).At(3).(px.Number).Int())
 }
 
+func TestSweepWithRef(t *testing.T) {
+	filename := "TestSearchGarbage.db"
+	deleteFile(filename)
+	defer deleteFile(filename)
+	id, err := NewIdentity(filename)
+	require.NoError(t, err)
+
+	// Insert something
+	require.NoError(t, id.Associate("a:i1", "e1"))
+	require.NoError(t, id.Associate("a:i2", "e2"))
+	require.NoError(t, id.AddReference("a:i3", "b:"))
+	require.NoError(t, id.Associate("b:i1", "e3"))
+	require.NoError(t, id.Associate("b:i2", "e4"))
+
+	// Bump era
+	require.NoError(t, id.BumpEra())
+
+	// Access using getExternal
+	checkGetExternal(t, id, "a:i1", "e1")
+	checkGetExternal(t, id, "b:i1", "e3")
+
+	// Check that element that wasn't accessed is found by SearchGarbage
+	require.NoError(t, id.Sweep("a:"))
+
+	// Retrieve the garbage bin
+	garbage, err := id.Garbage("a:")
+	require.NoError(t, err)
+	require.EqualValues(t, 2, garbage.Len())
+
+	// Never accessed between BumpEra and Sweep
+	require.EqualValues(t, "a:i2", garbage.At(0).(px.List).At(0).String())
+	require.EqualValues(t, "e2", garbage.At(0).(px.List).At(1).String())
+	require.EqualValues(t, "b:i2", garbage.At(1).(px.List).At(0).String())
+	require.EqualValues(t, "e4", garbage.At(1).(px.List).At(1).String())
+}
+
 func TestPurge(t *testing.T) {
 	filename := "TestPurge.db"
 	deleteFile(filename)
 	defer deleteFile(filename)
 	id, err := NewIdentity(filename)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Insert something
-	require.Nil(t, id.Associate("a:i1", "e1"))
-	require.Nil(t, id.Associate("a:i2", "e2"))
-	require.Nil(t, id.Associate("a:i3", "e3"))
+	require.NoError(t, id.Associate("a:i1", "e1"))
+	require.NoError(t, id.Associate("a:i2", "e2"))
+	require.NoError(t, id.Associate("a:i3", "e3"))
 
 	// Bump era
-	require.Nil(t, id.BumpEra())
+	require.NoError(t, id.BumpEra())
 
 	// Access using getExternal
 	checkGetExternal(t, id, "a:i1", "e1")
 	checkGetExternal(t, id, "a:i2", "e2")
-	require.Nil(t, id.RemoveInternal("a:i2"))
+	require.NoError(t, id.RemoveInternal("a:i2"))
 
 	// Check that element that wasn't accessed is found by SearchGarbage
-	require.Nil(t, id.Sweep("a:"))
+	require.NoError(t, id.Sweep("a:"))
 
 	// Purge
-	require.Nil(t, id.PurgeExternal("e1"))
-	require.Nil(t, id.PurgeInternal("a:i2"))
+	require.NoError(t, id.PurgeExternal("e1"))
+	require.NoError(t, id.PurgeInternal("a:i2"))
 
 	checkGetExternal(t, id, "a:i1", "")
 	checkGetExternal(t, id, "a:i2", "")
 
 	// Retrieve the garbage bin
 	garbage, err := id.Garbage("")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.EqualValues(t, 1, garbage.Len())
 
 	// Not purged


### PR DESCRIPTION
This commit adds methods to store and purge references from the identity
store. It also changes the sweep algorithm so that it will traverse such
references when it performs a sweep for a specific identity prefix. The
new functionality is needed when one workflow step calls on another
workflow (or explicit resource) because that workflow must be considered
part of subsequent garbage collections of the original workflow.

Relates to lyraproj/lyra#314