### PR TITLE
Add mutex to ensure that one thread at a time can access the database

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/lyraproj/identity
 
 require (
 	github.com/hashicorp/go-hclog v0.8.0
-	github.com/lyraproj/pcore v0.0.0-20190606102217-7824aee25201
+	github.com/lyraproj/pcore v0.0.0-20190614121034-381c91502dac
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
-	github.com/lyraproj/servicesdk v0.0.0-20190614081755-57bcd8399414
+	github.com/lyraproj/servicesdk v0.0.0-20190614121348-74e5b88a139c
 	github.com/stretchr/testify v1.3.0
 	go.etcd.io/bbolt v1.3.2
 )

--- a/go.sum
+++ b/go.sum
@@ -21,12 +21,12 @@ github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b h1:qGgMkFUQ
 github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b/go.mod h1:oQIFBu0fmkiSpSRROEgK5gnjQ/ZDrx3UdpRpT3791Gg=
 github.com/lyraproj/issue v0.0.0-20190606092846-e082d6813d15 h1:e1uefKgfSdC7uaYG9ipIZcpY+2gyefCYXQwsrWSdJLw=
 github.com/lyraproj/issue v0.0.0-20190606092846-e082d6813d15/go.mod h1:jqRRmAiVqjTehhncbKJPoC2AFoxxkritzzlfWioTa00=
-github.com/lyraproj/pcore v0.0.0-20190606102217-7824aee25201 h1:KlTHcsEPuRXi/cXY2OuK6tPUiGmO2HzgqAbd4UF7niA=
-github.com/lyraproj/pcore v0.0.0-20190606102217-7824aee25201/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
+github.com/lyraproj/pcore v0.0.0-20190614121034-381c91502dac h1:K4cTDfI72xRV+i7yOrZPyQqDFqbRq6smzgkxWUaSzv0=
+github.com/lyraproj/pcore v0.0.0-20190614121034-381c91502dac/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
-github.com/lyraproj/servicesdk v0.0.0-20190614081755-57bcd8399414 h1:VcRHhz+Fu2L5IbsIiMpCHVRBuroFacUx18kKjyL1Xio=
-github.com/lyraproj/servicesdk v0.0.0-20190614081755-57bcd8399414/go.mod h1:+IR74NuJQyJnnRUUrtp44Lu5Iu950oAwW0oSs2isvXI=
+github.com/lyraproj/servicesdk v0.0.0-20190614121348-74e5b88a139c h1:XvNS2pW3wufmgP4OZA64fBmu0x0EoU5uJy2q6Tm36cY=
+github.com/lyraproj/servicesdk v0.0.0-20190614121348-74e5b88a139c/go.mod h1:1JW0P7jN4e9J8ujxBYaVTLVd5dK7bqlVC0VvTZspwr8=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=


### PR DESCRIPTION
The way we're using the database where each request opens and closes it
didn't work in a thread-safe manner. This commit adds mutex to ensure
that the db is closed before the next thread opens it.

Closes lyraproj/lyra#244